### PR TITLE
Minor Footer Fixes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,8 +34,8 @@
       <div class="col-md-3 col-lg-3">
         <h5 class="title mb-4 font-bold">Contact</h5>
         <!--Info-->
-        <p><i>To contact us, you must use our community by creating a new account</i></p>
-        <p><a href="https://community.makeroid.io/groups/Makeroid" target="_blank"><i class="fa fa-comments mr-3"></i> community.makeroid.io</a></p>
+        <p><i>To contact us, you must use our community by creating a new account.</i></p>
+        <p><a href="https://community.makeroid.io" target="_blank"><i class="fa fa-comments mr-3"></i> community.makeroid.io</a></p>
         <p><a href="https://www.kvk.nl" target="_blank">KvK</a>: 71434976</p>
       </div>
       <!--/.Third column-->


### PR DESCRIPTION
- Added a dot at the end of the footer sentence for the community communication.
- Removed ".../groups/Makeroid" section from the community.makeroid.io link as new users won't be able to understand nothing from going to that page as they will already learn who is staff or not.