### PR TITLE
Made Makeroid title on nav not uppercase

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,5 @@
 <nav class="navbar fixed-top navbar-expand-lg navbar-dark deep-purple">
-  <a class="navbar-brand text-uppercase" href="/" style="font-family: 'Varela Round', sans-serif;">
+  <a class="navbar-brand" href="/" style="font-family: 'Varela Round', sans-serif;">
     <strong>Makeroid</strong>
   </a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
This PR makes the Makeroid title located on the top nav not uppercase to match the current logo.